### PR TITLE
Make ParseCancellationException extends from LogicException

### DIFF
--- a/src/Error/Exceptions/ParseCancellationException.php
+++ b/src/Error/Exceptions/ParseCancellationException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Antlr\Antlr4\Runtime\Error\Exceptions;
 
-class ParseCancellationException extends \Exception
+class ParseCancellationException extends \LogicException
 {
     public static function from(\Throwable $exception) : self
     {


### PR DESCRIPTION
LogicException is analogous to the RuntimeException in Java.