### PR TITLE
update platform requirements to allow php 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "antlr/antlr4-php-runtime",
   "type": "library",
-  "description": "PHP 7 runtime for ANTLR 4",
+  "description": "PHP 7 and 8.0 runtime for ANTLR 4",
   "keywords": ["antlr4", "php", "runtime"],
   "license": [
     "BSD-3-Clause"
@@ -9,7 +9,7 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require": {
-    "php": "^7.2",
+    "php": "7.4 - 8.0",
     "ext-mbstring": "*"
   },
   "require-dev": {


### PR DESCRIPTION
upped the minimum of 7.2 to 7.4 because of an incompatibility in `/src/Error/Exceptions/LexerNoViableAltException.php`:


```bash
FILE: src/Error/Exceptions/LexerNoViableAltException.php
-------------------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-------------------------------------------------------------------------------------------
 47 | ERROR | Throwing exceptions from __toString() was not allowed prior to PHP 7.4
-------------------------------------------------------------------------------------------
```