### PR TITLE
Fix for #12 -- Allowed memory size of 134217728 bytes exhausted.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require-dev": {
     "ergebnis/composer-normalize": "^2.15",
     "phpstan/extension-installer": "^1.0",
-    "phpstan/phpstan": "^1.4",
+    "phpstan/phpstan": "^1.9",
     "phpstan/phpstan-deprecation-rules": "^1.0",
     "phpstan/phpstan-strict-rules": "^1.1",
     "slevomat/coding-standard": "^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d73951acc3119aabd404dbbe0967053",
+    "content-hash": "367dc3d722296f940d17b2cfb8efbc38",
     "packages": [
         {
             "name": "psr/log",
@@ -622,16 +622,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.9.2",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa"
+                "reference": "d03bccee595e2146b7c9d174486b84f4dc61b0f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d6fdf01c53978b6429f1393ba4afeca39cc68afa",
-                "reference": "d6fdf01c53978b6429f1393ba4afeca39cc68afa",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/d03bccee595e2146b7c9d174486b84f4dc61b0f2",
+                "reference": "d03bccee595e2146b7c9d174486b84f4dc61b0f2",
                 "shasum": ""
             },
             "require": {
@@ -661,7 +661,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.9.2"
+                "source": "https://github.com/phpstan/phpstan/tree/1.9.4"
             },
             "funding": [
                 {
@@ -677,7 +677,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-10T09:56:11+00:00"
+            "time": "2022-12-17T13:33:52+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/src/Atn/ATNConfig.php
+++ b/src/Atn/ATNConfig.php
@@ -180,7 +180,7 @@ class ATNConfig implements Hashable
             $this->semanticContext->equals(SemanticContext::none())
                 ? ''
                 : ',' . $this->semanticContext,
-            $this->reachesIntoOuterContext > 0 ? ',up=' . $this->reachesIntoOuterContext : '',
+            $this->reachesIntoOuterContext > 0 ? ',up=' . $this->getOuterContextDepth() : '',
         );
     }
 }

--- a/src/Atn/ATNConfig.php
+++ b/src/Atn/ATNConfig.php
@@ -128,10 +128,10 @@ class ATNConfig implements Hashable
         }
 
         return $other instanceof self
+            && $this->state->stateNumber === $other->state->stateNumber
             && $this->alt === $other->alt
             && $this->isPrecedenceFilterSuppressed() === $other->isPrecedenceFilterSuppressed()
             && $this->semanticContext->equals($other->semanticContext)
-            && Equality::equals($this->state, $other->state)
             && Equality::equals($this->context, $other->context);
     }
 

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -135,7 +135,7 @@ class ATNConfigSet implements Hashable
             $this->hasSemanticContext = true;
         }
 
-        if ($config->reachesIntoOuterContext > 0) {
+        if ($config->getOuterContextDepth() > 0) {
             $this->dipsIntoOuterContext = true;
         }
 

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Antlr\Antlr4\Runtime\Atn;
 
 use Antlr\Antlr4\Runtime\Atn\SemanticContexts\SemanticContext;
+use Antlr\Antlr4\Runtime\Atn\States\ATNState;
 use Antlr\Antlr4\Runtime\Comparison\Equality;
 use Antlr\Antlr4\Runtime\Comparison\Hashable;
 use Antlr\Antlr4\Runtime\Comparison\Hasher;
 use Antlr\Antlr4\Runtime\PredictionContexts\PredictionContext;
 use Antlr\Antlr4\Runtime\Utils\BitSet;
 use Antlr\Antlr4\Runtime\Utils\DoubleKeyMap;
-use Antlr\Antlr4\Runtime\Utils\Map;
 use Antlr\Antlr4\Runtime\Utils\Set;
 
 /**
@@ -125,12 +125,14 @@ class ATNConfigSet implements Hashable
         }
 
         // A previous (s,i,pi,_), merge with it and save result
+        /** @var bool $rootIsWildcard */
         $rootIsWildcard = !$this->fullCtx;
 
         if ($existing->context === null || $config->context === null) {
             throw new \LogicException('Unexpected null context.');
         }
 
+        /** @var PredictionContext $merged */
         $merged = PredictionContext::merge($existing->context, $config->context, $rootIsWildcard, $mergeCache);
 
         // No need to check for existing->context, config->context in cache
@@ -162,8 +164,12 @@ class ATNConfigSet implements Hashable
         return $this->configs;
     }
 
+    /**
+     * @return Set<ATNState>
+     */
     public function getStates(): Set
     {
+        /** @var Set<ATNState> $states */
         $states = new Set();
         foreach ($this->configs as $config) {
             $states->add($config->state);

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -91,13 +91,12 @@ class ATNConfigSet implements Hashable
                 }
 
                 if ($left == null || $right == null) return false;
-                return $left->state->stateNumber == $right->state->stateNumber
-                        && $left->alt == $right->alt
-                        && $left->semanticContext->equals($right->semanticContext);
+                return true;
             }
 
             public function hash(Hashable $value): int
             {
+                if (!($value instanceof ATNConfig)) return 0;
                 return Hasher::hash(
                     $value->state->stateNumber,
                     $value->alt,

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -6,14 +6,13 @@ namespace Antlr\Antlr4\Runtime\Atn;
 
 use Antlr\Antlr4\Runtime\Atn\SemanticContexts\SemanticContext;
 use Antlr\Antlr4\Runtime\Comparison\Equality;
-use Antlr\Antlr4\Runtime\Comparison\Equivalence;
 use Antlr\Antlr4\Runtime\Comparison\Hashable;
 use Antlr\Antlr4\Runtime\Comparison\Hasher;
 use Antlr\Antlr4\Runtime\PredictionContexts\PredictionContext;
 use Antlr\Antlr4\Runtime\Utils\BitSet;
 use Antlr\Antlr4\Runtime\Utils\DoubleKeyMap;
-use Antlr\Antlr4\Runtime\Utils\Set;
 use Antlr\Antlr4\Runtime\Utils\Map;
+use Antlr\Antlr4\Runtime\Utils\Set;
 
 /**
  * Specialized {@see Set} of `{@see ATNConfig}`s that can track info
@@ -282,7 +281,9 @@ class ATNConfigSet implements Hashable
             throw new \InvalidArgumentException('This method is not implemented for readonly sets.');
         }
 
-	if (!($item instanceof ATNConfig)) return false;
+        if (!($item instanceof ATNConfig)) {
+            return false;
+        }
 
         return $this->configLookup->contains($item);
     }

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -360,7 +360,7 @@ class ATNConfigSet implements Hashable
         return \sprintf(
             '[%s]%s%s%s%s',
             \implode(', ', $this->configs),
-            $this->hasSemanticContext ? ',hasSemanticContext=' . $this->hasSemanticContext : '',
+            $this->hasSemanticContext ? ',hasSemanticContext=true' : '',
             $this->uniqueAlt !== ATN::INVALID_ALT_NUMBER ? ',uniqueAlt=' . $this->uniqueAlt : '',
             $this->conflictingAlts !== null ? ',conflictingAlts=' . $this->conflictingAlts : '',
             $this->dipsIntoOuterContext ? ',dipsIntoOuterContext' : '',

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -306,7 +306,7 @@ class ATNConfigSet implements Hashable
 
         $this->configs = [];
         $this->cachedHashCode = -1;
-        $this->configLookup = new Map();
+        $this->configLookup = new ConfigHashSet();
     }
 
     public function isReadOnly(): bool

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -35,7 +35,8 @@ class ATNConfigSet implements Hashable
      * All configs but hashed by (s, i, _, pi) not including context. Wiped out
      * when we go readonly as this set becomes a DFA state.
      */
-    public ?Map $configLookup = null;
+    // ConfigHashSet : Dictionary<ATNConfig, ATNConfig>
+    public ?ConfigHashSet $configLookup = null;
 
     /**
      * Track the elements as they are added to the set; supports get(i).
@@ -83,32 +84,7 @@ class ATNConfigSet implements Hashable
          * not including context. Wiped out when we go readonly as this se
          * becomes a DFA state.
          */
-        $this->configLookup = new Map(new class implements Equivalence {
-            public function equivalent(Hashable $left, Hashable $right): bool
-            {
-                if ($left === $right) {
-                    return true;
-                }
-
-                if ($left === null || $right === null) return false;
-                return true;
-            }
-
-            public function hash(Hashable $value): int
-            {
-                if (!($value instanceof ATNConfig)) return 0;
-                return Hasher::hash(
-                    $value->state->stateNumber,
-                    $value->alt,
-                    $value->semanticContext,
-                    );              
-            }
-
-            public function equals(object $other): bool
-            {
-                return $other instanceof self;
-            }
-        });
+        $this->configLookup = new ConfigHashSet();
 
         $this->fullCtx = $fullCtx;
     }
@@ -305,6 +281,8 @@ class ATNConfigSet implements Hashable
         if ($this->configLookup === null) {
             throw new \InvalidArgumentException('This method is not implemented for readonly sets.');
         }
+
+	if (!($item instanceof ATNConfig)) return false;
 
         return $this->configLookup->contains($item);
     }

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -311,7 +311,7 @@ class ATNConfigSet implements Hashable
         }
 
         $this->configs = [];
-        $this->cachedHashCode = -1;
+        $this->cachedHashCode = null;
         $this->configLookup = new ConfigHashSet();
     }
 

--- a/src/Atn/ATNConfigSet.php
+++ b/src/Atn/ATNConfigSet.php
@@ -90,7 +90,7 @@ class ATNConfigSet implements Hashable
                     return true;
                 }
 
-                if ($left == null || $right == null) return false;
+                if ($left === null || $right === null) return false;
                 return true;
             }
 

--- a/src/Atn/ATNSimulator.php
+++ b/src/Atn/ATNSimulator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Antlr\Antlr4\Runtime\Atn;
 
 use Antlr\Antlr4\Runtime\Dfa\DFAState;
+use Antlr\Antlr4\Runtime\PredictionContexts\IdentityHashMap;
 use Antlr\Antlr4\Runtime\PredictionContexts\PredictionContext;
 use Antlr\Antlr4\Runtime\PredictionContexts\PredictionContextCache;
 
@@ -92,7 +93,7 @@ abstract class ATNSimulator
 
     public function getCachedContext(PredictionContext $context): PredictionContext
     {
-        $visited = [];
+        $visited = new IdentityHashMap();
 
         return PredictionContext::getCachedPredictionContext(
             $context,

--- a/src/Atn/ConfigHashSet.php
+++ b/src/Atn/ConfigHashSet.php
@@ -15,6 +15,8 @@ use Antlr\Antlr4\Runtime\Utils\Map;
  * {@code (s,i,_,semctx)} to be equal. Unfortunately, this key effectively doubles
  * the number of objects associated with ATNConfigs. The other solution is to
  * use a hash table that lets us specify the equals/hashcode operation.
+ *
+ * @extends Map<ATNConfig, ATNConfig>
  */
 final class ConfigHashSet extends Map
 {
@@ -66,6 +68,7 @@ final class ConfigHashSet extends Map
 
     public function getOrAdd(ATNConfig $config): ATNConfig
     {
+        /** @var ?ATNConfig $existing */
         $existing = null;
         if ($this->tryGetValue($config, $existing)) {
             return $existing;

--- a/src/Atn/ConfigHashSet.php
+++ b/src/Atn/ConfigHashSet.php
@@ -45,7 +45,7 @@ final class ConfigHashSet extends Map
 
                 public function hash(Hashable $value): int
                 {
-                    if (!($value instanceof ATNConfig)) {
+                    if (! $value instanceof ATNConfig) {
                         return 0;
                     }
 

--- a/src/Atn/ConfigHashSet.php
+++ b/src/Atn/ConfigHashSet.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antlr\Antlr4\Runtime\Atn;
+
+use Antlr\Antlr4\Runtime\Atn\SemanticContexts\SemanticContext;
+use Antlr\Antlr4\Runtime\Comparison\Equality;
+use Antlr\Antlr4\Runtime\Comparison\Equivalence;
+use Antlr\Antlr4\Runtime\Comparison\Hashable;
+use Antlr\Antlr4\Runtime\Comparison\Hasher;
+use Antlr\Antlr4\Runtime\PredictionContexts\PredictionContext;
+use Antlr\Antlr4\Runtime\Utils\BitSet;
+use Antlr\Antlr4\Runtime\Utils\DoubleKeyMap;
+use Antlr\Antlr4\Runtime\Utils\Set;
+use Antlr\Antlr4\Runtime\Utils\Map;
+
+/**
+ * The reason that we need this is because we don't want the hash map to use
+ * the standard hash code and equals. We need all configurations with the same
+ * {@code (s,i,_,semctx)} to be equal. Unfortunately, this key effectively doubles
+ * the number of objects associated with ATNConfigs. The other solution is to
+ * use a hash table that lets us specify the equals/hashcode operation.
+ */
+final class ConfigHashSet extends Map
+{
+	public function __construct(Equivalence $comparer = null)
+	{
+		if ($comparer === null)
+			parent::__construct(new class implements Equivalence {
+				public function equivalent(Hashable $left, Hashable $right): bool
+				{
+					if ($left === $right) {
+						return true;
+					}
+
+					/** @phpstan-ignore-next-line */
+					if ($left == null) return false;
+					/** @phpstan-ignore-next-line */
+					if ($right == null) return false;
+
+					if (! $left instanceof ATNConfig) return false;
+					if (! $right instanceof ATNConfig) return false;
+
+					return $left->state->stateNumber === $right->state->stateNumber
+							&& $left->alt === $right->alt
+							&& $left->semanticContext->equals($right->semanticContext);
+				}
+
+				public function hash(Hashable $value): int
+				{
+					if (!($value instanceof ATNConfig)) return 0;
+					return Hasher::hash(
+						$value->state->stateNumber,
+						$value->alt,
+						$value->semanticContext,
+						);              
+				}
+
+				public function equals(object $other): bool
+				{
+					return $other instanceof self;
+				}
+			});
+		else
+			parent::__construct($comparer);
+	}
+
+	public function getOrAdd(ATNConfig $config): ATNConfig
+	{
+		$existing = null;
+		if ($this->tryGetValue($config, $existing))
+			return $existing;
+		else
+		{
+			$this->put($config, $config);
+			return $config;
+		}
+	}
+}

--- a/src/Atn/LexerATNConfig.php
+++ b/src/Atn/LexerATNConfig.php
@@ -63,15 +63,15 @@ final class LexerATNConfig extends ATNConfig
             return false;
         }
 
-        if (!parent::equals($other)) {
-            return false;
-        }
-
         if ($this->passedThroughNonGreedyDecision !== $other->passedThroughNonGreedyDecision) {
             return false;
         }
 
-        return Equality::equals($this->lexerActionExecutor, $other->lexerActionExecutor);
+        if (!Equality::equals($this->lexerActionExecutor, $other->lexerActionExecutor)) {
+            return false;
+        }
+
+        return parent::equals($other);
     }
 
     private static function checkNonGreedyDecision(LexerATNConfig $source, ATNState $target): bool

--- a/src/Atn/OrderedATNConfigSet.php
+++ b/src/Atn/OrderedATNConfigSet.php
@@ -21,7 +21,7 @@ final class OrderedATNConfigSet extends ATNConfigSet
                 if ($left === $right) {
                     return true;
                 }
-                if ($left == null || $right == null) return false;
+                if ($left === null || $right === null) return false;
                 return $left->equals($right);
             }
 

--- a/src/Atn/OrderedATNConfigSet.php
+++ b/src/Atn/OrderedATNConfigSet.php
@@ -30,7 +30,7 @@ final class OrderedATNConfigSet extends ATNConfigSet
                     return false;
                 }
 
-                return $left->equals($right);
+                return $left->equivalent($right);
             }
 
             public function hash(Hashable $value): int

--- a/src/Atn/OrderedATNConfigSet.php
+++ b/src/Atn/OrderedATNConfigSet.php
@@ -3,8 +3,11 @@
 declare(strict_types=1);
 
 namespace Antlr\Antlr4\Runtime\Atn;
-
-use Antlr\Antlr4\Runtime\Utils\Set;
+use Antlr\Antlr4\Runtime\Comparison\Equality;
+use Antlr\Antlr4\Runtime\Comparison\Equivalence;
+use Antlr\Antlr4\Runtime\Comparison\Hashable;
+use Antlr\Antlr4\Runtime\Comparison\Hasher;
+use Antlr\Antlr4\Runtime\Utils\Map;
 
 final class OrderedATNConfigSet extends ATNConfigSet
 {
@@ -12,6 +15,25 @@ final class OrderedATNConfigSet extends ATNConfigSet
     {
         parent::__construct();
 
-        $this->configLookup = new Set();
+        $this->configLookup = new Map(new class implements Equivalence {
+            public function equivalent(Hashable $left, Hashable $right): bool
+            {
+                if ($left === $right) {
+                    return true;
+                }
+                if ($left == null || $right == null) return false;
+                return $left->equals($right);
+            }
+
+            public function hash(Hashable $value): int
+            {
+                return $value->hashCode();
+            }
+
+            public function equals(object $other): bool
+            {
+                return $other instanceof self;
+            }
+        });
     }
 }

--- a/src/Atn/OrderedATNConfigSet.php
+++ b/src/Atn/OrderedATNConfigSet.php
@@ -3,11 +3,9 @@
 declare(strict_types=1);
 
 namespace Antlr\Antlr4\Runtime\Atn;
-use Antlr\Antlr4\Runtime\Comparison\Equality;
+
 use Antlr\Antlr4\Runtime\Comparison\Equivalence;
 use Antlr\Antlr4\Runtime\Comparison\Hashable;
-use Antlr\Antlr4\Runtime\Comparison\Hasher;
-use Antlr\Antlr4\Runtime\Utils\Map;
 
 final class OrderedATNConfigSet extends ATNConfigSet
 {
@@ -23,9 +21,14 @@ final class OrderedATNConfigSet extends ATNConfigSet
                 }
 
                 /** @phpstan-ignore-next-line */
-	        if ($left == null) return false;
+                if ($left === null) {
+                    return false;
+                }
+
                 /** @phpstan-ignore-next-line */
-		if ($right == null) return false;
+                if ($right === null) {
+                    return false;
+                }
 
                 return $left->equals($right);
             }

--- a/src/Atn/OrderedATNConfigSet.php
+++ b/src/Atn/OrderedATNConfigSet.php
@@ -15,13 +15,18 @@ final class OrderedATNConfigSet extends ATNConfigSet
     {
         parent::__construct();
 
-        $this->configLookup = new Map(new class implements Equivalence {
+        $this->configLookup = new ConfigHashSet(new class implements Equivalence {
             public function equivalent(Hashable $left, Hashable $right): bool
             {
                 if ($left === $right) {
                     return true;
                 }
-                if ($left === null || $right === null) return false;
+
+                /** @phpstan-ignore-next-line */
+	        if ($left == null) return false;
+                /** @phpstan-ignore-next-line */
+		if ($right == null) return false;
+
                 return $left->equals($right);
             }
 

--- a/src/Atn/OrderedATNConfigSet.php
+++ b/src/Atn/OrderedATNConfigSet.php
@@ -30,7 +30,7 @@ final class OrderedATNConfigSet extends ATNConfigSet
                     return false;
                 }
 
-                return $left->equivalent($right);
+                return $left->equals($right);
             }
 
             public function hash(Hashable $value): int

--- a/src/Atn/States/ATNState.php
+++ b/src/Atn/States/ATNState.php
@@ -152,7 +152,7 @@ abstract class ATNState implements Hashable
 
     public function hashCode(): int
     {
-        return $this->getStateType();
+        return $this->stateNumber;
     }
 
     abstract public function getStateType(): int;

--- a/src/ParserTraceListener.php
+++ b/src/ParserTraceListener.php
@@ -27,17 +27,17 @@ final class ParserTraceListener implements ParseTreeListener
             $this->parser->getRuleNames()[$context->getRuleIndex()],
             $token === null? '' : $token->getText() ?? '',
         );
-        print("\n");
+        echo \PHP_EOL;
     }
 
     public function visitTerminal(TerminalNode $node): void
     {
-        print \sprintf(
+        echo \sprintf(
             'consume %s rule %s',
             $node->getSymbol(),
             $this->parser->getCurrentRuleName(),
         );
-        print("\n");
+        echo \PHP_EOL;
     }
 
     public function exitEveryRule(ParserRuleContext $context): void
@@ -45,12 +45,12 @@ final class ParserTraceListener implements ParseTreeListener
         $stream = $this->parser->getTokenStream();
         $token = $stream?->LT(1);
 
-        print \sprintf(
+        echo \sprintf(
             'exit    %s, LT(1)=%s',
             $this->parser->getRuleNames()[$context->getRuleIndex()],
             $token === null? '' : $token->getText() ?? '',
         );
-        print("\n");
+        echo \PHP_EOL;
     }
 
     public function visitErrorNode(ErrorNode $node): void

--- a/src/ParserTraceListener.php
+++ b/src/ParserTraceListener.php
@@ -27,15 +27,17 @@ final class ParserTraceListener implements ParseTreeListener
             $this->parser->getRuleNames()[$context->getRuleIndex()],
             $token === null? '' : $token->getText() ?? '',
         );
+        print("\n");
     }
 
     public function visitTerminal(TerminalNode $node): void
     {
-        echo \sprintf(
+        print \sprintf(
             'consume %s rule %s',
             $node->getSymbol(),
             $this->parser->getCurrentRuleName(),
         );
+        print("\n");
     }
 
     public function exitEveryRule(ParserRuleContext $context): void
@@ -43,11 +45,12 @@ final class ParserTraceListener implements ParseTreeListener
         $stream = $this->parser->getTokenStream();
         $token = $stream?->LT(1);
 
-        echo \sprintf(
+        print \sprintf(
             'exit    %s, LT(1)=%s',
             $this->parser->getRuleNames()[$context->getRuleIndex()],
             $token === null? '' : $token->getText() ?? '',
         );
+        print("\n");
     }
 
     public function visitErrorNode(ErrorNode $node): void

--- a/src/PredictionContexts/ArrayPredictionContext.php
+++ b/src/PredictionContexts/ArrayPredictionContext.php
@@ -86,7 +86,7 @@ final class ArrayPredictionContext extends PredictionContext
             return false;
         }
 
-        if ($this->returnStates === $other->returnStates) {
+        if (!($this->returnStates === $other->returnStates)) {
             return false;
         }
 

--- a/src/PredictionContexts/IdentityHashMap.php
+++ b/src/PredictionContexts/IdentityHashMap.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antlr\Antlr4\Runtime\PredictionContexts;
+
+use Antlr\Antlr4\Runtime\Comparison\Equivalence;
+use Antlr\Antlr4\Runtime\Comparison\Hashable;
+use Antlr\Antlr4\Runtime\Utils\Map;
+
+/**
+ * @extends Map<PredictionContext,PredictionContext>
+ */
+class IdentityHashMap extends Map
+{
+    public function __construct()
+    {
+        parent::__construct(new class implements Equivalence {
+            public function equivalent(Hashable $left, Hashable $right): bool
+            {
+                if (! $left instanceof PredictionContext) {
+                    return false;
+                }
+
+                if (! $right instanceof PredictionContext) {
+                    return false;
+                }
+
+                return $left === $right;
+            }
+
+            public function hash(Hashable $value): int
+            {
+                if (! $value instanceof PredictionContext) {
+                    return 0;
+                }
+
+                return $value->hashCode();
+            }
+
+            public function equals(object $other): bool
+            {
+                return $other instanceof self;
+            }
+        });
+    }
+}

--- a/src/PredictionContexts/PredictionContext.php
+++ b/src/PredictionContexts/PredictionContext.php
@@ -605,19 +605,16 @@ abstract class PredictionContext implements Hashable
         }
     }
 
-    /**
-     * @param array<PredictionContext|null> $visited
-     */
     public static function getCachedPredictionContext(
         PredictionContext $context,
         PredictionContextCache $contextCache,
-        array &$visited,
+        IdentityHashMap &$visited,
     ): self {
         if ($context->isEmpty()) {
             return $context;
         }
 
-        $existing = $visited[\spl_object_id($context)] ?? null;
+        $existing = $visited->get($context);
 
         if ($existing !== null) {
             return $existing;
@@ -626,7 +623,7 @@ abstract class PredictionContext implements Hashable
         $existing = $contextCache->get($context);
 
         if ($existing !== null) {
-            $visited[\spl_object_id($context)] = $existing;
+            $visited->put($context, $existing);
 
             return $existing;
         }
@@ -660,7 +657,7 @@ abstract class PredictionContext implements Hashable
         if (!$changed) {
             $contextCache->add($context);
 
-            $visited[\spl_object_id($context)] = $context;
+            $visited->put($context, $context);
 
             return $context;
         }
@@ -680,8 +677,8 @@ abstract class PredictionContext implements Hashable
         }
 
         $contextCache->add($updated);
-        $visited[\spl_object_id($updated)] = $updated;
-        $visited[\spl_object_id($context)] = $updated;
+        $visited->put($updated, $updated);
+        $visited->put($context, $updated);
 
         return $updated;
     }

--- a/src/PredictionContexts/PredictionContext.php
+++ b/src/PredictionContexts/PredictionContext.php
@@ -427,13 +427,17 @@ abstract class PredictionContext implements Hashable
         }
 
         // merge sorted payloads a + b => M
+	/** @var int $i */
         $i = 0;// walks a
+	/** @var int $j */
         $j = 0;// walks b
+	/** @var int $k */
         $k = 0;// walks target M array
 
-        $mergedReturnStates = [];
+        /** @var int[] $mergedReturnStates */
+	$mergedReturnStates = [];
         for ($ini = 0; $ini < \count($a->returnStates) + \count($b->returnStates); $ini++) {
-                $mergedReturnStates[$ini] = null;
+                $mergedReturnStates[$ini] = 0;
         }
         $mergedParents = [];
         for ($ini = 0; $ini < \count($a->returnStates) + \count($b->returnStates); $ini++) {
@@ -585,6 +589,7 @@ abstract class PredictionContext implements Hashable
         $uniqueParents = new Map();
 
         foreach ($parents as $parent) {
+            /** @phpstan-ignore-next-line */
             if ($parent != null && !$uniqueParents->contains($parent)) {
                 // don't replace.
                 $uniqueParents->put($parent, $parent);
@@ -592,6 +597,7 @@ abstract class PredictionContext implements Hashable
         }
 
         foreach ($parents as $i => $parent) {
+            /** @phpstan-ignore-next-line */
             if ($parent != null)
                 $parents[$i] = $uniqueParents->get($parent);
         }

--- a/src/PredictionContexts/PredictionContext.php
+++ b/src/PredictionContexts/PredictionContext.php
@@ -492,8 +492,8 @@ abstract class PredictionContext implements Hashable
         // copy over any payloads remaining in either array
         if ($i < \count($a->returnStates)) {
             /** @var int $p */
-            $p = $j;
-            for (; $p < \count($b->returnStates); $p++) {
+            $p = $i;
+            for (; $p < \count($a->returnStates); $p++) {
                 $mergedParents[$k] = $a->parents[$p];
                 $mergedReturnStates[$k] = $a->returnStates[$p];
                 $k++;

--- a/src/PredictionContexts/PredictionContext.php
+++ b/src/PredictionContexts/PredictionContext.php
@@ -294,8 +294,7 @@ abstract class PredictionContext implements Hashable
                 $payloads[0] = $b->returnState;
                 $payloads[1] = $a->returnState;
                 $parents = [$b->parent, $a->parent];
-            }
-            else {
+            } else {
                 $payloads[0] = $a->returnState;
                 $payloads[1] = $b->returnState;
                 $parents = [$a->parent, $b->parent];
@@ -427,15 +426,15 @@ abstract class PredictionContext implements Hashable
         }
 
         // merge sorted payloads a + b => M
-	/** @var int $i */
+        /** @var int $i */
         $i = 0;// walks a
-	/** @var int $j */
+        /** @var int $j */
         $j = 0;// walks b
-	/** @var int $k */
+        /** @var int $k */
         $k = 0;// walks target M array
 
-        /** @var int[] $mergedReturnStates */
-	$mergedReturnStates = [];
+        /** @var array<int> $mergedReturnStates */
+        $mergedReturnStates = [];
         for ($ini = 0; $ini < \count($a->returnStates) + \count($b->returnStates); $ini++) {
                 $mergedReturnStates[$ini] = 0;
         }
@@ -491,18 +490,18 @@ abstract class PredictionContext implements Hashable
         }
 
         // copy over any payloads remaining in either array
-        if ($i < \count($a->returnStates))
-        {
-            for ($p = $i; $p < \count($a->returnStates); $p++)
-            {
+        if ($i < \count($a->returnStates)) {
+            /** @var int $p */
+            $p = $j;
+            for (; $p < \count($b->returnStates); $p++) {
                 $mergedParents[$k] = $a->parents[$p];
                 $mergedReturnStates[$k] = $a->returnStates[$p];
                 $k++;
             }
-        }
-        else {
-            for ($p = $j; $p < \count($b->returnStates); $p++)
-            {
+        } else {
+            /** @var int $p */
+            $p = $j;
+            for (; $p < \count($b->returnStates); $p++) {
                 $mergedParents[$k] = $b->parents[$p];
                 $mergedReturnStates[$k] = $b->returnStates[$p];
                 $k++;
@@ -512,11 +511,13 @@ abstract class PredictionContext implements Hashable
         // trim merged if we combined a few that had same stack tops
         if ($k < \count($mergedParents)) {
             // write index < last position; trim
-            if ($k === 1)
-            { // for just one merged element, return singleton top
+            if ($k === 1) {
+                // for just one merged element, return singleton top
                 $a_ = SingletonPredictionContext::create($mergedParents[0], $mergedReturnStates[0]);
 
-                if ($mergeCache !== null) $mergeCache->set($a, $b, $a_);
+                if ($mergeCache !== null) {
+                    $mergeCache->set($a, $b, $a_);
+                }
 
                 return $a_;
             }
@@ -526,7 +527,6 @@ abstract class PredictionContext implements Hashable
             // mergedReturnStates = Arrays.CopyOf(mergedReturnStates, k);
             $mergedReturnStates = \array_slice($mergedReturnStates, 0, $k);
         }
-
 
         $M = new ArrayPredictionContext($mergedParents, $mergedReturnStates);
 
@@ -578,28 +578,30 @@ abstract class PredictionContext implements Hashable
         if ($mergeCache !== null) {
             $mergeCache->set($a, $b, $M);
         }
+
         return $M;
     }
 
     /**
-     * @param array<PredictionContext> $parents
+     * @param array<PredictionContext|null> $parents
      */
     protected static function combineCommonParents(array &$parents): void
     {
+        /** @var Map<PredictionContext, PredictionContext> $uniqueParents */
         $uniqueParents = new Map();
 
+        /** @var PredictionContext|null $parent */
         foreach ($parents as $parent) {
-            /** @phpstan-ignore-next-line */
-            if ($parent != null && !$uniqueParents->contains($parent)) {
+            if ($parent !== null && !$uniqueParents->contains($parent)) {
                 // don't replace.
                 $uniqueParents->put($parent, $parent);
             }
         }
 
         foreach ($parents as $i => $parent) {
-            /** @phpstan-ignore-next-line */
-            if ($parent != null)
+            if ($parent !== null) {
                 $parents[$i] = $uniqueParents->get($parent);
+            }
         }
     }
 

--- a/src/Utils/Map.php
+++ b/src/Utils/Map.php
@@ -32,6 +32,7 @@ class Map implements Equatable, \Countable, \IteratorAggregate
     {
         return $this->count() === 0;
     }
+
     public function count(): int
     {
         return $this->size;
@@ -136,7 +137,7 @@ class Map implements Equatable, \Countable, \IteratorAggregate
 
     public function equals(object $other): bool
     {
-	return false;
+        return false;
     }
 
     /**
@@ -189,11 +190,10 @@ class Map implements Equatable, \Countable, \IteratorAggregate
 
         return $left === $right;
     }
-    
+
     /**
      * @param K $key
      * @param V $value
-     * @return bool
      */
     public function tryGetValue(Hashable $key, mixed &$value): bool
     {
@@ -206,10 +206,11 @@ class Map implements Equatable, \Countable, \IteratorAggregate
         foreach ($this->table[$hash] as $index => [$entryKey, $entryValue]) {
             if ($this->equivalence->equivalent($key, $entryKey)) {
                 $value = $entryValue;
-		return true;
+
+                return true;
             }
         }
 
-	return false;
+        return false;
     }
 }

--- a/src/Utils/Map.php
+++ b/src/Utils/Map.php
@@ -28,6 +28,10 @@ final class Map implements Equatable, \Countable, \IteratorAggregate
         $this->equivalence = $equivalence ?? new DefaultEquivalence();
     }
 
+    public function isEmpty(): bool
+    {
+        return $this->count() === 0;
+    }
     public function count(): int
     {
         return $this->size;
@@ -211,5 +215,33 @@ final class Map implements Equatable, \Countable, \IteratorAggregate
         }
 
         return $left === $right;
+    }
+    public function getOrAdd(Hashable $value): Hashable
+    {
+        $key = $value;
+        $hash = $this->equivalence->hash($value);
+
+        if (!isset($this->table[$hash])) {
+            $this->table[$hash] = [];
+        }
+
+        foreach ($this->table[$hash] as $index => [$entryKey, $entryValue]) {
+            if ($this->equivalence->equivalent($key, $entryKey)) {
+                return $entryValue;
+            }
+        }
+
+        foreach ($this->table[$hash] as $index => [$entryKey]) {
+            if ($this->equivalence->equivalent($key, $entryKey)) {
+                $this->table[$hash][$index] = [$key, $value];
+                return $value;
+            }
+        }
+
+        $this->table[$hash][] = [$key, $value];
+
+        $this->size++;
+
+        return $value;
     }
 }


### PR DESCRIPTION
## Summary
This is a fix for Issue #12. The main problem was due to some confusion over Map, Set, ===, hash(), and equals(), which is easy to get wrong because these data structures are pretty complicated. (In fact, I think I may have the equivalent() method wrong in the anonymous class in ATNConfigSet.)

### Checklist

I've tested this with [grammars-v4/aql](https://github.com/antlr/grammars-v4/tree/master/aql). The parse completes for for.aql now, and the parse tree is the same between PHP and CSharp.

_I will be checking the parser ATN trace for all grammars in grammars-v4 and examples._
